### PR TITLE
Add support for the Orange Pi Prime

### DIFF
--- a/plex/config.json
+++ b/plex/config.json
@@ -13,6 +13,9 @@
   ],
   "machine": [
     "intel-nuc",
+    "odroid-c2",
+    "odroid-xu",
+    "orangepi-prime",
     "qemux86",
     "qemux86-64",
     "qemuarm",
@@ -20,9 +23,7 @@
     "raspberrypi2",
     "raspberrypi3",
     "raspberrypi3-64",
-    "tinker",
-    "odroid-c2",
-    "odroid-xu"
+    "tinker"
   ],
   "map": [
     "config:rw",


### PR DESCRIPTION
# Proposed Changes

Orange Pi Prime should be supported and is therefore added to the list,
furthermore this PR sorts the list alphabetically.
 https://github.com/home-assistant/hassio/pull/829

## Related Issues

NA