### PR TITLE
Added `config` mount to configuration

### DIFF
--- a/plex/config.json
+++ b/plex/config.json
@@ -7,7 +7,7 @@
   "webui": "http://[HOST]:[PORT:32400]/web",
   "startup": "services",
   "arch": ["aarch64", "amd64", "armv7", "i386"],
-  "map": ["share:rw", "ssl"],
+  "map": ["share:rw", "ssl", "config"],
   "boot": "auto",
   "ports": {
     "1900/udp": 1900,


### PR DESCRIPTION
# Proposed Changes

This change will allow a user to use the `secrets.yaml` file for the claim code that is used by Plex.

## Related Issues

n/a

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/