### PR TITLE
Add note about DLNA support to docs, cleanup port 1900

### DIFF
--- a/plex/DOCS.md
+++ b/plex/DOCS.md
@@ -111,30 +111,6 @@ Example:
 http://hassio.local:32400,http://192.168.1.88:32400,http://mydomain.duckdns.org:32400
 ```
 
-## Port 1900 add-on conflicts
-
-Plex Media server uses port `1900` for access to the Plex DLNA Server. This port
-is also used by multiple other add-ons, like the AirSonos and UniFi add-ons.
-
-In case they conflict, the Plex Media Server add-on will fail to start.
-The following error message is shown in the Hass.io system log:
-
-```txt
-[hassio.docker] Can't start addon_40817795_plex: 500 Server Error:
-Internal Server Error ("driver failed programming external connectivity
-on endpoint addon_40817795_plex):
-Error starting userland proxy: listen udp 0.0.0.0:1900:
-bind: address already in use
-```
-
-You have two choices:
-
-- Disable or remove the conflicting add-on
-- Change the port number 1900 to something else.
-
-The last option will cause you to lose the DLNA capabilities of the
-Plex Media Server.
-
 ## Known issues and limitations
 
 - This add-on does support ARM-based devices, nevertheless, they must
@@ -144,12 +120,13 @@ Plex Media Server.
   and is probably not able to stream your media; therefore it is not
   recommended using this add-on on such a device.
 - This add-on cannot add/mount any additional USB or other devices for you.
-  This is a Hass.io limitation. In case you'd like to use extra devices,
+  This is a Home Assistant limitation. In case you'd like to use extra devices,
   you'll have to modify the host system yourself and is not supported by the
-  Hass.io or Community add-ons team.
+  Home Assistant project or Community add-ons team.
 - A Plex Pass gives you exclusive access to new features, which are
   available through a Beta version channel of the media server. At this
   time, running this "Beta" version, is not supported by this add-on.
+- This add-on does not support Plex over DLNA.
 
 ## Changelog & Releases
 

--- a/plex/config.json
+++ b/plex/config.json
@@ -9,7 +9,6 @@
   "arch": ["aarch64", "amd64", "armv7", "i386"],
   "map": ["media:rw", "share:rw", "ssl"],
   "ports": {
-    "1900/udp": 1900,
     "3005/tcp": 3005,
     "8324/tcp": 8324,
     "32400/tcp": 32400,
@@ -22,7 +21,6 @@
     "33443/tcp": 33443
   },
   "ports_description": {
-    "1900/udp": "Plex DLNA Server",
     "3005/tcp": "Plex Home Theater via Plex Companion",
     "8324/tcp": "Plex for Roku via Plex Companion",
     "32400/tcp": "Plex Media Server Interface",


### PR DESCRIPTION
# Proposed Changes

DLNA is cool, but in order for it to work, it needs to drop the network to host mode. Doing that will cause problems with other add-ons as Plex will claim 1900 (which has been an annoyance already).

This PR adds a note to the add-on documentation to make clean DLNA is not supported by the add-on. Additionally, it cleans up port 1900 (which was originally needed for DLNA), to make the add-on less problematic to set up when using e.g., Uni-Fi or Aircast.

closes #72
