### PR TITLE
Exclude cache from backup

### DIFF
--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -39,8 +39,8 @@ ports_description:
   33443/tcp: WebTools
 hassio_api: true
 backup_exclude:
-  - '**/Plex Media Server/Cache/**'
-  - '**/Plex Media Server/Plug-in Support/Caches/**'
+  - "**/Plex Media Server/Cache/**"
+  - "**/Plex Media Server/Plug-in Support/Caches/**"
 options:
   claim_code: ""
   webtools: false

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -38,6 +38,9 @@ ports_description:
   33400/tcp: WebTools
   33443/tcp: WebTools
 hassio_api: true
+backup_exclude:
+  - '**/Plex Media Server/Cache/**'
+  - '**/Plex Media Server/Plug-in Support/Caches/**'
 options:
   claim_code: ""
   webtools: false


### PR DESCRIPTION
# Proposed Changes

The backup of the addon includes all the cache, which can add up to hundreds of MB (in my case 150MB) and there is no real reason to back it up and take space on local (and remote) disks.

To fix this, I added exclude globs on both cache directories.

I tested locally the removal of those dirs and plex was operating fine afterward

@frenck can you please CR?

references:

https://support.plex.tv/articles/204041406-where-are-plex-media-server-cached-images-stored-on-my-computer/
https://support.plex.tv/articles/202967376-clearing-plugin-channel-agent-http-caches/