### PR TITLE
Exclude metadata directories from backup

### DIFF
--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -41,6 +41,11 @@ hassio_api: true
 backup_exclude:
   - "**/Plex Media Server/Cache/**"
   - "**/Plex Media Server/Plug-in Support/Caches/**"
+  - "**/Plex Media Server/Logs/**"
+  - "**/Plex Media Server/Metadata/**"
+  - "**/Plex Media Server/Media/**"
+  - "**/Plex Media Server/Crash Reports/**"
+  - "**/Plex Media Server/Diagnostics/**"
 options:
   claim_code: ""
   webtools: false


### PR DESCRIPTION
# Proposed Changes

The backup of the addon includes all the metadata, which can add up to tens of MB (in my case 49MB) and there is no real reason to back it up and take space on local (and remote) disks (once you restore, you can instruct plex to refresh the metadata)

To fix this, I added exclude globs on both metadata directories and some other redundant directories.

I tested locally the removal of those dirs and plex was operating fine afterward

@frenck can you please CR?

references:

https://support.plex.tv/articles/202529153-why-is-my-plex-media-server-directory-so-large/