### PR TITLE
Map possible hardware acceleration devices into add-on

### DIFF
--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -16,6 +16,9 @@ map:
   - media:rw
   - share:rw
   - ssl
+devices:
+  - /dev/dri:/dev/dri
+  - /dev/vchiq:/dev/vchiq
 ports:
   3005/tcp: 3005
   8324/tcp: 8324

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -17,8 +17,8 @@ map:
   - share:rw
   - ssl
 devices:
-  - /dev/dri:/dev/dri
-  - /dev/vchiq:/dev/vchiq
+  - /dev/dri
+  - /dev/vchiq
 ports:
   3005/tcp: 3005
   8324/tcp: 8324


### PR DESCRIPTION
# Proposed Changes

Maps `dri` and `vchiq` into the add-on container (if available).

