### PR TITLE
Add support for more Intel based Hardware Acceleration

### DIFF
--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -18,6 +18,9 @@ map:
   - ssl
 devices:
   - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
   - /dev/vchiq
 ports:
   3005/tcp: 3005


### PR DESCRIPTION
With just /dev/dri PLEX doesn’t seem to be able to access the GPU on the host.

Other PLEX add-ons have these device paths added as well and do work with hardware acceleration.

# Proposed Changes

> Maps dri/card0, dri/card1 and /dri/renderD128 into the add-on container (if available).