### PR TITLE
⬆️ Update Plex Media Server and dependencies

### DIFF
--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:7.4.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:7.7.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -14,7 +14,7 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         xmlstarlet=1.6.1-3 \
-        uuid-runtime=2.38.1-5+deb12u1 \
+        uuid-runtime=2.38.1-5+deb12u3 \
         unrar=1:6.2.6-1+deb12u1 \
     \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
@@ -22,7 +22,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then ARCH="armhf"; fi \
     \
     && curl -J -L -o /tmp/plexmediaserver.deb \
-        "https://downloads.plex.tv/plex-media-server-new/1.41.3.9292-bc7397402/debian/plexmediaserver_1.41.3.9292-bc7397402_${ARCH}.deb" \
+        "https://downloads.plex.tv/plex-media-server-new/1.41.4.9463-630c9f557/debian/plexmediaserver_1.41.4.9463-630c9f557_${ARCH}.deb" \
     \
     && dpkg --install /tmp/plexmediaserver.deb \
     \

--- a/plex/build.yaml
+++ b/plex/build.yaml
@@ -1,8 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base:7.4.0
-  amd64: ghcr.io/hassio-addons/debian-base:7.4.0
-  armv7: ghcr.io/hassio-addons/debian-base:7.4.0
+  aarch64: ghcr.io/hassio-addons/debian-base:7.7.0
+  amd64: ghcr.io/hassio-addons/debian-base:7.7.0
+  armv7: ghcr.io/hassio-addons/debian-base:7.7.0
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes
⬆️ Update Plex Media Server to 1.41.4.9463:
Changes since https://forums.plex.tv/t/plex-media-server/30447/658

⬆️ Bump debian-base to 7.7.0
Changes since https://github.com/hassio-addons/addon-debian-base/releases/tag/v7.4.0

⬆️ Bump uuid-runtime to 2.38.1-5+deb12u3
Changes since 2.38.1-5+deb12u1: https://metadata.ftp-master.debian.org/changelogs//main/u/util-linux/util-linux_2.38.1-5+deb12u3_changelog



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the container’s base system to a more recent version for enhanced stability and performance across supported architectures.
	- Updated key dependencies, including an upgrade to the Plex Media Server, ensuring the latest features and improved security.
	- Revised related components to maintain compatibility with current platform standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->