### PR TITLE
Add Media & Metadata folders to backup_exclude

### DIFF
--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -47,6 +47,8 @@ backup_exclude:
   - "**/Plex Media Server/Logs/**"
   - "**/Plex Media Server/Crash Reports/**"
   - "**/Plex Media Server/Diagnostics/**"
+  - "**/Plex Media Server/Media/**"
+  - "**/Plex Media Server/Metadata/**"
 options:
   claim_code: ""
 schema:


### PR DESCRIPTION
# Proposed Changes

> 2 lines of very complex and difficult paths have been added to backup_exclude in config.yaml. These two folders appear to have a reasonable appetite. Not sure if this should be optional. If yes, excusez moi and pardon my French. 

## Related Issues

> [Issue 252](https://github.com/hassio-addons/addon-plex/issues/252)
> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated backup settings to exclude Media and Metadata directories from backups in Plex Media Server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->