### PR TITLE
dynamic plexmediaserver URL

### DIFF
--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -5,32 +5,23 @@ FROM ${BUILD_FROM}
 # Set shell to bash with strict error handling
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG BUILD_ARCH
+ARG BUILD_ARCH=amd64
+
 
 # Build arguments for version control and metadata
 # hadolint ignore=DL3008
 RUN \
-    case "$BUILD_ARCH" in \
-      x86_64)  ARCH=amd64 ;; \
-      aarch64) ARCH=arm64 ;; \
-      armv7l)  ARCH=armhf ;; \
-      *) echo "Unsupported architecture: $BUILD_ARCH" >&2; exit 1 ;; \
-    esac && \
-    PLEX_FULL="$(curl -s https://plex.tv/pms/downloads/5.json | jq -r '[.. | .version? // empty | select(type=="string")][0]')" && \
-    PLEX_VERSION="${PLEX_FULL%-*}" && \
-    PLEX_HASH="${PLEX_FULL##*-}" && \
-    if [ -z "$PLEX_VERSION" ] || [ "$PLEX_VERSION" = "null" ] || [ -z "$PLEX_HASH" ]; then \
-        echo "Could not determine Plex version/hash from API" >&2; \
-        exit 1; \
-    fi && \
-    echo "Plex Media Server version: ${PLEX_VERSION} (${PLEX_HASH}) ARCH: ${ARCH} BUILDARCH: ${BUILD_ARCH}" \
-    && echo "deb http://deb.debian.org/debian trixie contrib non-free" \
-        >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian trixie contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
         xmlstarlet>="1.6.1-4" \
         uuid-runtime=2.41-5 \
         unrar=1:7.1.8-1 \
     \
+    && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
+    && if [ "${BUILD_ARCH}" = "amd64" ]; then ARCH="amd64"; fi \
+    \
+    && read -r PLEX_VERSION PLEX_HASH <<< "$(curl -s https://plex.tv/pms/downloads/5.json | jq -r '[.. | .version? // empty | select(type=="string")][0]' | tr '-' ' ')"  \
+    && echo "Plex Media Server version: ${PLEX_VERSION} (${PLEX_HASH}) ARCH: ${ARCH} BUILDARCH: ${BUILD_ARCH}" \
    && curl -J -L -o /tmp/plexmediaserver.deb \
   "https://downloads.plex.tv/plex-media-server-new/${PLEX_VERSION}-${PLEX_HASH}/debian/plexmediaserver_${PLEX_VERSION}-${PLEX_HASH}_${ARCH}.deb" \ 
   && dpkg --install /tmp/plexmediaserver.deb \

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -5,19 +5,25 @@ FROM ${BUILD_FROM}
 # Set shell to bash with strict error handling
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+ARG BUILD_ARCH
+
 # Build arguments for version control and metadata
 # hadolint ignore=DL3008
 RUN \
-    read BUILD_ARCH <<< "$(uname -m)" && \
     case "$BUILD_ARCH" in \
       x86_64)  ARCH=amd64 ;; \
       aarch64) ARCH=arm64 ;; \
       armv7l)  ARCH=armhf ;; \
       *) echo "Unsupported architecture: $BUILD_ARCH" >&2; exit 1 ;; \
     esac && \
-    read PLEX_VERSION PLEX_HASH <<< "$(curl -s https://plex.tv/pms/downloads/5.json | jq -r '[.. | .version? // empty | select(type=="string")][0]' | tr '-' ' ')"  \
-    # CHECK: Verify that the version and hash were extracted correctly
-    && echo "Plex Media Server version: ${PLEX_VERSION} (${PLEX_HASH}) ARCH: ${ARCH} BUILDARCH: ${BUILD_ARCH}" \
+    PLEX_FULL="$(curl -s https://plex.tv/pms/downloads/5.json | jq -r '[.. | .version? // empty | select(type=="string")][0]')" && \
+    PLEX_VERSION="${PLEX_FULL%-*}" && \
+    PLEX_HASH="${PLEX_FULL##*-}" && \
+    if [ -z "$PLEX_VERSION" ] || [ "$PLEX_VERSION" = "null" ] || [ -z "$PLEX_HASH" ]; then \
+        echo "Could not determine Plex version/hash from API" >&2; \
+        exit 1; \
+    fi && \
+    echo "Plex Media Server version: ${PLEX_VERSION} (${PLEX_HASH}) ARCH: ${ARCH} BUILDARCH: ${BUILD_ARCH}" \
     && echo "deb http://deb.debian.org/debian trixie contrib non-free" \
         >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -28,14 +34,14 @@ RUN \
    && curl -J -L -o /tmp/plexmediaserver.deb \
   "https://downloads.plex.tv/plex-media-server-new/${PLEX_VERSION}-${PLEX_HASH}/debian/plexmediaserver_${PLEX_VERSION}-${PLEX_HASH}_${ARCH}.deb" \ 
   && dpkg --install /tmp/plexmediaserver.deb \
-    \
+  \
     && apt-get -y clean \
     && rm -fr \
         /tmp/* \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*
 
-        # Copy root filesystem
+# Copy root filesystem
 COPY rootfs /
 
 # Build arguments

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -2,32 +2,32 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:8.1.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-# Set shell
+# Set shell to bash with strict error handling
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Setup base system
-ARG BUILD_ARCH=amd64
-ARG PLEX_VERSION=1.42.2.10156
-ARG PLEX_HASH=f737b826c
-
+# Build arguments for version control and metadata
 # hadolint ignore=DL3008
 RUN \
-    echo "deb http://deb.debian.org/debian trixie contrib non-free" \
-        >> /etc/apt/sources.list \
-    && apt-get update \
-    \
-    && apt-get install -y --no-install-recommends \
+    read BUILD_ARCH <<< "$(uname -m)" && \
+    case "$BUILD_ARCH" in \
+      x86_64)  ARCH=amd64 ;; \
+      aarch64) ARCH=arm64 ;; \
+      armv7l)  ARCH=armhf ;; \
+      *) echo "Unsupported architecture: $BUILD_ARCH" >&2; exit 1 ;; \
+    esac && \
+    read PLEX_VERSION PLEX_HASH <<< "$(curl -s https://plex.tv/pms/downloads/5.json | jq -r '[.. | .version? // empty | select(type=="string")][0]' | tr '-' ' ')"  \
+    # CHECK: Verify that the version and hash were extracted correctly
+    && echo "Plex Media Server version: ${PLEX_VERSION} (${PLEX_HASH}) ARCH: ${ARCH} BUILDARCH: ${BUILD_ARCH}" \
+    && echo "deb http://deb.debian.org/debian trixie contrib non-free" \
+        >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
         xmlstarlet>="1.6.1-4" \
         uuid-runtime=2.41-5 \
         unrar=1:7.1.8-1 \
     \
-    && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
-    && if [ "${BUILD_ARCH}" = "amd64" ]; then ARCH="amd64"; fi \
-    \
-    && curl -J -L -o /tmp/plexmediaserver.deb \
-        "https://downloads.plex.tv/plex-media-server-new/${PLEX_VERSION}-${PLEX_HASH}/debian/plexmediaserver_${PLEX_VERSION}-${PLEX_HASH}_${ARCH}.deb" \
-    \
-    && dpkg --install /tmp/plexmediaserver.deb \
+   && curl -J -L -o /tmp/plexmediaserver.deb \
+  "https://downloads.plex.tv/plex-media-server-new/${PLEX_VERSION}-${PLEX_HASH}/debian/plexmediaserver_${PLEX_VERSION}-${PLEX_HASH}_${ARCH}.deb" \ 
+  && dpkg --install /tmp/plexmediaserver.deb \
     \
     && apt-get -y clean \
     && rm -fr \
@@ -35,7 +35,7 @@ RUN \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*
 
-# Copy root filesystem
+        # Copy root filesystem
 COPY rootfs /
 
 # Build arguments


### PR DESCRIPTION
### Summary
Make the Plex Media Server download source dynamically determined at build time instead of relying on pre-defined version metadata.

#### Disclaimer
As always, if this is unwanted or if my logic is too creative, excusez-moi and pardon my French.

### Proposed Changes
- Resolve the Plex Media Server version and release hash dynamically via Plex’s official downloads API during the build.
- Detect the target architecture at build time and map it to Plex’s expected naming (amd64, arm64, armhf).
- Download the matching plexmediaserver.deb in the same build step to avoid Docker variable scoping issues.

> ([Github link][autolink-references] to related issues or pull requests)
every PR that resembles a version update chore. 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatic architecture mapping for multi-arch builds (amd64 → amd64, aarch64 → arm64)
  * Dynamic retrieval of Plex version and checksum from upstream API at build time
  * Removed hard-coded build-time version/checksum arguments; added pre-build validation of detected values
  * Streamlined package download/install flow, consolidated runtime shell behaviour and preserved cleanup/metadata labeling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->