### PR TITLE
Remove redundant trixie repository from Dockerfile

### DIFF
--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -11,9 +11,7 @@ ARG PLEX_VERSION=1.43.1.10611-1e34174b1
 
 # hadolint ignore=DL3008
 RUN \
-    echo "deb http://deb.debian.org/debian trixie contrib non-free" \
-        >> /etc/apt/sources.list \
-    && apt-get update \
+    apt-get update \
     \
     && apt-get install -y --no-install-recommends \
         xmlstarlet>="1.6.1-4" \

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -11,7 +11,9 @@ ARG PLEX_VERSION=1.43.1.10611-1e34174b1
 
 # hadolint ignore=DL3008
 RUN \
-    apt-get update \
+    echo "deb http://deb.debian.org/debian trixie contrib non-free non-free-firmware" \
+        >> /etc/apt/sources.list \
+    && apt-get update \
     \
     && apt-get install -y --no-install-recommends \
         xmlstarlet>="1.6.1-4" \


### PR DESCRIPTION
# Proposed Changes

The debian-base:9.3.0 base image is already based on Debian 13 (trixie), making the explicit sources.list addition redundant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build process by removing an additional Debian repository configuration step while maintaining all package installation and application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->