### PR TITLE
Track APT package versions with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,9 +32,24 @@
       "depNameTemplate": "plexmediaserver",
       "datasourceTemplate": "custom.plex",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["//Dockerfile$/"],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "\\s\\s(?<depName>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
+      ],
+      "versioningTemplate": "deb",
+      "datasourceTemplate": "repology",
+      "depNameTemplate": "debian_13/{{depName}}"
     }
   ],
   "packageRules": [
+    {
+      "matchDatasources": ["repology"],
+      "automerge": true
+    },
     {
       "groupName": "App base image",
       "matchDatasources": ["docker"]

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     && apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        xmlstarlet>="1.6.1-4" \
+        xmlstarlet=1.6.1-4 \
         uuid-runtime=2.41-5 \
         unrar=1:7.1.8-1 \
     \

--- a/plex/Dockerfile
+++ b/plex/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     && apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        xmlstarlet=1.6.1-4 \
+        xmlstarlet>="1.6.1-4" \
         uuid-runtime=2.41-5 \
         unrar=1:7.1.8-1 \
     \


### PR DESCRIPTION
# Proposed Changes

Pins xmlstarlet to an exact version (was using >=) and adds a Renovate custom manager using the repology datasource to automatically track updates for all APT packages pinned in the Dockerfile (xmlstarlet, uuid-runtime, unrar)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
