### PR TITLE
Remove unused variable declaration in finish script

### DIFF
--- a/plex/rootfs/etc/s6-overlay/s6-rc.d/plex/finish
+++ b/plex/rootfs/etc/s6-overlay/s6-rc.d/plex/finish
@@ -4,7 +4,6 @@
 # Home Assistant Community App: Plex Media Server
 # Take down the S6 supervision tree when the Plex Media Server fails
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"


### PR DESCRIPTION
# Proposed Changes

exit_code was declared but never referenced anywhere in the script

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
