### PR TITLE
Update example hostname to homeassistant.local

### DIFF
--- a/plex/DOCS.md
+++ b/plex/DOCS.md
@@ -93,7 +93,7 @@ to Plex. You can list multiple if you'd like, separated by a comma.
 Example:
 
 ```txt
-http://hassio.local:32400,http://192.168.1.88:32400,http://mydomain.duckdns.org:32400
+http://homeassistant.local:32400,http://192.168.1.88:32400,http://mydomain.duckdns.org:32400
 ```
 
 ## Known issues and limitations


### PR DESCRIPTION
# Proposed Changes

hassio.local hasn't been in use for a long time at this point 😓 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example values in the Plex documentation to reflect current server access URL naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->